### PR TITLE
update tests for ethers v6

### DIFF
--- a/test/builders/build/eth-api/libraries/ethers/deploy-contract.js
+++ b/test/builders/build/eth-api/libraries/ethers/deploy-contract.js
@@ -19,9 +19,9 @@ describe("Ethers - Deploy a Contract", function () {
     },
   };
   // Create ethers provider
-  const provider = new ethers.providers.StaticJsonRpcProvider(
+  const provider = new ethers.JsonRpcProvider(
     providerRPC.dev.rpc,
-    {
+     {
       chainId: providerRPC.dev.chainId,
       name: providerRPC.dev.name,
     }
@@ -58,8 +58,7 @@ describe("Ethers - Deploy a Contract", function () {
     let wallet = new ethers.Wallet(alice.pk, provider);
 
     const incrementer = new ethers.ContractFactory(abi, bytecode, wallet);
-    const contract = await incrementer.deploy([5]);
-
+    const contract = await incrementer.deploy(5);
     return contract;
   };
 
@@ -80,22 +79,16 @@ describe("Ethers - Deploy a Contract", function () {
   });
 
   describe("Deploy Contract - deploy.js", async () => {
-    let contractAddress;
-    it("should deploy the contract", async () => {
+    it("should return the correct deployed bytecode", async () => {
       const contractFile = compileContract();
       const bytecode = contractFile.evm.bytecode.object;
       const abi = contractFile.abi;
 
       const contract = await deployContract(abi, bytecode);
-      const res = await (await contract.deployed()).deployTransaction.wait();
+      await contract.waitForDeployment();
+      const deployedCode = await contract.getDeployedCode();
 
-      contractAddress = res.contractAddress;
-
-      assert.equal(res.status, 1);
-    }).timeout(15000);
-    it("should return the correct contract code", async () => {
-      const code = await provider.getCode(contractAddress);
-      assert.equal(code, deployedBytecode);
+      assert.equal(deployedCode, deployedBytecode);
     }).timeout(15000);
   });
 
@@ -106,8 +99,8 @@ describe("Ethers - Deploy a Contract", function () {
       const abi = contractFile.abi;
 
       const contract = await deployContract(abi, bytecode);
-      await contract.deployed();
-      const contractAddress = contract.address;
+      await contract.waitForDeployment();
+      const contractAddress = contract.target;
 
       const incrementer = new ethers.Contract(contractAddress, abi, provider);
 
@@ -124,7 +117,9 @@ describe("Ethers - Deploy a Contract", function () {
       const abi = contractFile.abi;
 
       const contract = await deployContract(abi, bytecode);
-      const contractAddress = contract.address;
+      await contract.waitForDeployment();
+
+      const contractAddress = contract.target;
 
       const wallet = new ethers.Wallet(alice.pk, provider);
       const incrementer = new ethers.Contract(contractAddress, abi, wallet);
@@ -143,7 +138,8 @@ describe("Ethers - Deploy a Contract", function () {
       const abi = contractFile.abi;
 
       const contract = await deployContract(abi, bytecode);
-      const contractAddress = contract.address;
+      await contract.waitForDeployment();
+      const contractAddress = contract.target;
 
       const wallet = new ethers.Wallet(alice.pk, provider);
       const incrementer = new ethers.Contract(contractAddress, abi, wallet);

--- a/test/builders/build/eth-api/libraries/ethers/send-transaction.js
+++ b/test/builders/build/eth-api/libraries/ethers/send-transaction.js
@@ -11,7 +11,7 @@ describe('Ethers - Send a Transaction', function () {
     },
   };
   // Create ethers provider
-  const provider = new ethers.providers.StaticJsonRpcProvider(
+  const provider = new ethers.JsonRpcProvider(
     providerRPC.dev.rpc,
     {
       chainId: providerRPC.dev.chainId,
@@ -23,15 +23,15 @@ describe('Ethers - Send a Transaction', function () {
     "address": "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac",
     "pk": "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133",
   }
-  const bob = new ethers.Wallet.createRandom().address;
+  const bob = ethers.Wallet.createRandom().address;
 
   describe('Check Balances -  balances.js', async () => {
     it('should return a balance for alice', async () => {
-      const balance = ethers.utils.formatEther(await provider.getBalance(alice.address));
+      const balance = ethers.formatEther(await provider.getBalance(alice.address));
       assert.equal(balance > 0, true);
     });
     it('should return a balance for bob', async () => {
-      const balance = ethers.utils.formatEther(await provider.getBalance(bob));
+      const balance = ethers.formatEther(await provider.getBalance(bob));
       assert.equal(balance, 0);
     });
   });
@@ -41,7 +41,7 @@ describe('Ethers - Send a Transaction', function () {
       const value = 10;
       const tx = {
         to: bob,
-        value: ethers.utils.parseEther(value.toString()),
+        value: ethers.parseEther(value.toString()),
       }
       const wallet = new ethers.Wallet(alice.pk, provider);
       const res = await (await wallet.sendTransaction(tx)).wait();
@@ -50,7 +50,7 @@ describe('Ethers - Send a Transaction', function () {
       assert.equal(res.status, 1);
     }).timeout(15000);
     it('should return an updated balance for bob', async () => {
-      const balance = ethers.utils.formatEther(await provider.getBalance(bob));
+      const balance = ethers.formatEther(await provider.getBalance(bob));
       assert.equal(balance, 10);
     });
   });


### PR DESCRIPTION
This PR updates our ethers code examples for v6. The changes required were as follows:

- Update the provider from `new ethers.providers.StaticJsonRpcProvider` to [`new ethers.JsonRpcProvider`](https://docs.ethers.org/v6/api/providers/jsonrpc/)
- Use [`await contract.waitForDeployment();`](https://docs.ethers.org/v6/api/contract/#BaseContract-waitForDeployment) for contract deployments instead of `await contract.deployed()`
- Deployed contract addresses can now be retrieved from [`contract.target`](https://docs.ethers.org/v6/api/contract/#BaseContract-target) instead of `contract.address`
- To get contract deployed bytecode, we can now use [`await contract.getDeployedCode()`](https://docs.ethers.org/v6/api/contract/#BaseContract-getDeployedCode)
- Util methods are no longer accessed via `ethers.utils.*`, they can directly be access using `ethers.*` ([see related migration guide odds and ends section](https://docs.ethers.org/v6/migrating/#migrate-other))