### PR TITLE
fix failing web3py tests

### DIFF
--- a/test/builders/build/eth-api/libraries/web3py/test_deploy_contract.py
+++ b/test/builders/build/eth-api/libraries/web3py/test_deploy_contract.py
@@ -104,7 +104,7 @@ class TestDeployContract(unittest.TestCase):
         incrementer = self.web3.eth.contract(address=contract_address, abi=abi)
 
         value = 3
-        increment_tx = incrementer.functions.increment(value).buildTransaction(
+        increment_tx = incrementer.functions.increment(value).build_transaction(
             {
                 'from': self.alice,
                 'nonce': self.web3.eth.get_transaction_count(self.alice),
@@ -130,7 +130,7 @@ class TestDeployContract(unittest.TestCase):
 
         incrementer = self.web3.eth.contract(address=contract_address, abi=abi)
 
-        increment_tx = incrementer.functions.reset().buildTransaction(
+        increment_tx = incrementer.functions.reset().build_transaction(
             {
                 'from': self.alice,
                 'nonce': self.web3.eth.get_transaction_count(self.alice),

--- a/test/builders/build/eth-api/libraries/web3py/test_send_transaction.py
+++ b/test/builders/build/eth-api/libraries/web3py/test_send_transaction.py
@@ -18,12 +18,12 @@ class TestSendTransaction(unittest.TestCase):
         self.bob = Account.from_key("0x" + random).address
 
     def test_alices_balance(self):
-        alices_balance = self.web3.fromWei(
+        alices_balance = self.web3.from_wei(
             self.web3.eth.get_balance(self.alice), "ether")
         self.assertGreater(alices_balance, 0)
 
     def test_bobs_balance(self):
-        bobs_balance = self.web3.fromWei(
+        bobs_balance = self.web3.from_wei(
             self.web3.eth.get_balance(self.bob), "ether")
         self.assertEqual(bobs_balance, 0)
 
@@ -36,7 +36,7 @@ class TestSendTransaction(unittest.TestCase):
                 "gasPrice": self.web3.eth.generate_gas_price(),
                 "gas": 21000,
                 "to": self.bob,
-                "value": self.web3.toWei("1", "ether"),
+                "value": self.web3.to_wei("1", "ether"),
             },
             self.alice_pk,
         )
@@ -45,7 +45,7 @@ class TestSendTransaction(unittest.TestCase):
 
         self.assertEqual(tx_receipt["status"], 1)
 
-        bobs_balance = self.web3.fromWei(
+        bobs_balance = self.web3.from_wei(
             self.web3.eth.get_balance(self.bob), "ether")
         self.assertEqual(bobs_balance, 1)
 


### PR DESCRIPTION
Web3py has been deprecating all of their camelCase named functions in favor of snake_case, there were a few here that have been removed:

- `buildTransaction` is now `build_transaction`
- `fromWei` is now `from_wei`
- `toWei` is now `to_wei`